### PR TITLE
Fix the bug that inserts a wrong character at the beginning of a line

### DIFF
--- a/spec/toneletterSpec.js
+++ b/spec/toneletterSpec.js
@@ -86,6 +86,16 @@ describe('On toneletter input with lang: "th"', function() {
         $el.appendTo('body');
     });
 
+    describe('Pressing a tone key at the beginning of a line', function() {
+        beforeEach(function() {
+            $el.trigger(helper.createKeypressEvent('1'));
+        });
+
+        it('should insert a number as normal', function() {
+            expect($el.val()).toBe('1');
+        });
+    });
+
     PHONETICS.forEach(function(keyAndConverted) {
         var key = keyAndConverted[0],
         converted = keyAndConverted[1];

--- a/src/toneletter.js
+++ b/src/toneletter.js
@@ -194,6 +194,7 @@
             __getPreviousCharacter: function() {
                 var position = this.__getCursorPosition();
                 var prevChar = this.el.value.charAt(position - 1);
+                if (prevChar === '') return prevChar;
                 // Skip if the previous character is just a tone symbol
                 if (this.__isTone(prevChar)) {
                     return this.el.value.charAt(position - 2);


### PR DESCRIPTION
Fixed the bug that when pressing tone keys at the beginning of a line, it inserts a wrong character.
